### PR TITLE
Scope help menu referer fallback to Livewire update requests

### DIFF
--- a/src/Support/DocumentationResolver.php
+++ b/src/Support/DocumentationResolver.php
@@ -29,7 +29,20 @@ class DocumentationResolver
             return $controller;
         }
 
-        return static::resolveControllerFromReferer($request);
+        // Only Livewire update requests may borrow the referer's controller: there the
+        // current route is the livewire/update endpoint, so the referer is the only way
+        // back to the page being viewed. On a full page load, falling back would show a
+        // doc-less page the previous page's documentation.
+        if (static::isLivewireUpdateRequest($request)) {
+            return static::resolveControllerFromReferer($request);
+        }
+
+        return null;
+    }
+
+    protected static function isLivewireUpdateRequest(Request $request): bool
+    {
+        return $request->hasHeader('X-Livewire');
     }
 
     protected static function resolveControllerFromReferer(Request $request): mixed

--- a/tests/DocumentationResolverTest.php
+++ b/tests/DocumentationResolverTest.php
@@ -14,12 +14,69 @@ class TestDocumentationController implements HasKnowledgeBase
     public function __invoke(): void {}
 }
 
-it('resolves documentation from the referer route during livewire update requests', function () {
-    app('router')->get('/docs-page', TestDocumentationController::class);
+class TestUndocumentedController
+{
+    public function __invoke(): void {}
+}
+
+function requestForRoute(string $uri, array $server = []): Request
+{
+    $request = Request::create($uri, 'GET', [], [], [], $server);
+    $route = app('router')->getRoutes()->match($request);
+    $request->setRouteResolver(fn () => $route);
+
+    return $request;
+}
+
+// Mirrors a real Livewire update request: the update endpoint resolves to Livewire's
+// own (undocumented) controller, not null, and the X-Livewire header is present.
+function livewireUpdateRequest(string $referer, string $headerValue = '1'): Request
+{
+    app('router')->post('/livewire/update', TestUndocumentedController::class);
 
     $request = Request::create('/livewire/update', 'POST', [], [], [], [
+        'HTTP_REFERER' => $referer,
+        'HTTP_X_LIVEWIRE' => $headerValue,
+    ]);
+    $route = app('router')->getRoutes()->match($request);
+    $request->setRouteResolver(fn () => $route);
+
+    return $request;
+}
+
+it('resolves documentation from the referer route during livewire update requests', function (string $headerValue) {
+    app('router')->get('/docs-page', TestDocumentationController::class);
+
+    $request = livewireUpdateRequest('http://localhost/docs-page', $headerValue);
+
+    expect(DocumentationResolver::resolve($request))->toBe(['test-docs']);
+})->with([
+    // Livewire v4 sends X-Livewire: 1; v3 sends the header with an empty value.
+    'livewire v4 header value' => '1',
+    'livewire v3 header value' => '',
+]);
+
+it('resolves empty during livewire update requests when the referer page has no documentation', function () {
+    app('router')->get('/no-docs-page', TestUndocumentedController::class);
+
+    $request = livewireUpdateRequest('http://localhost/no-docs-page');
+
+    expect(DocumentationResolver::resolve($request))->toBe([]);
+});
+
+it('resolves documentation from the current route on a full page load', function () {
+    app('router')->get('/docs-page', TestDocumentationController::class);
+
+    expect(DocumentationResolver::resolve(requestForRoute('/docs-page')))->toBe(['test-docs']);
+});
+
+it('does not borrow the referer documentation on a full page load of a page without documentation', function () {
+    app('router')->get('/docs-page', TestDocumentationController::class);
+    app('router')->get('/no-docs-page', TestUndocumentedController::class);
+
+    $request = requestForRoute('/no-docs-page', [
         'HTTP_REFERER' => 'http://localhost/docs-page',
     ]);
 
-    expect(DocumentationResolver::resolve($request))->toBe(['test-docs']);
+    expect(DocumentationResolver::resolve($request))->toBe([]);
 });


### PR DESCRIPTION
## Problem

On a full page load of a Filament page with no knowledge-base documentation of its own, the Help menu borrowed the referring page's documentation and showed a misleading Help button. Loading the same page directly (no referrer) correctly showed no Help button.

First noticed in Connect's reports cluster (the doc-less Projects report showing the PM Engagement doc), and reproduced identically in Journey (the doc-less Vouchers list showing the Support Contacts doc). Affects every panel in both apps, since the help menu is injected app-wide via the plugin render hook.

ClickUp: https://app.clickup.com/t/868kgabyu

## Root cause

The referer fallback added in 4802d09 ("Stabilize help menu documentation context") exists for Livewire update requests, where the current route is the `livewire/update` endpoint rather than the page being viewed — the referrer is the only way back to that page. The fallback was not scoped to those requests, so ordinary page loads used it too.

## Fix

Gate `resolveControllerFromReferer()` on the `X-Livewire` request header:

- Every Livewire v3 and v4 update request sends it (v4 as `1`, v3 with an empty value), matching Livewire's own `isLivewireRequest()` check, so the stabilization behavior is preserved.
- Full page loads and `wire:navigate` requests (which send `X-Livewire-Navigate` instead) never carry it, so a doc-less page now resolves to no documentation and renders no Help button.

## Testing

- Resolver test suite rewritten: referer resolution during update requests (dataset covering both v3 and v4 header shapes), empty result when the referrer page is undocumented, own-route resolution on full page loads, and the regression case — a doc-less page load with a documented referrer resolves empty. Update-request tests resolve `/livewire/update` to a real undocumented controller, mirroring production, and the suite was mutation-tested against wrong-gate implementations.
- Browser-verified in both Connect and Journey with the patched package: bug path gone, documented pages keep their own docs, Help modal opens, Help button survives Topbar/page `$refresh` during Livewire updates.

The pre-existing ArchTest failure (`dd('test')` in `src/KnowledgeBase.php:30`) is unrelated and untouched.